### PR TITLE
Kill docker containers for a project

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,12 @@ The "srm" tool which securely deletes data. We use it to wipe the repos (despite
 apt-get install secure-delete
 ```
 
+To remove the docker containers created while working on a project, please use following command (get "dockerkill.sh" from bin directory of this repo):
+
+```bash
+./dockerkill.sh <container-name>
+```
+
 # FAQ - Frequently Asked Questions
 
 ##### _What's a virtual assistant?_

--- a/bin/dockerkill.sh
+++ b/bin/dockerkill.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [ $# -ne 1 ]; then
+    echo $0: usage: dockerkill containername
+    exit 1
+fi
+
+echo "Choose option to remove"
+
+containername="$1"
+
+OLD_IFS="$IFS"
+IFS="
+"
+select container_id in $(docker ps -a --filter "name=$containername" --format '{{.ID}} {{.Image}} {{.Names}}'); 
+do 
+  echo "Removing: $container_id"
+  # stop any running containers
+  echo $container_id | awk '{print $1}' | xargs docker stop ;
+
+  # remove the container
+  echo $container_id | awk '{print $1}' | xargs docker rm ;
+
+  docker rmi $(docker images -q -f dangling=true)
+done
+
+IFS="$OLD_IFS"

--- a/bin/dockerkill.sh
+++ b/bin/dockerkill.sh
@@ -16,12 +16,12 @@ select container_id in $(docker ps -a --filter "name=$containername" --format '{
 do 
   echo "Removing: $container_id"
   # stop any running containers
-  echo $container_id | awk '{print $1}' | xargs docker stop ;
+  echo "$container_id" | awk '{print $1}' | xargs docker stop ;
 
   # remove the container
-  echo $container_id | awk '{print $1}' | xargs docker rm ;
-
-  docker rmi $(docker images -q -f dangling=true)
+  echo "$container_id" | awk '{print $1}' | xargs docker rm ;
 done
+
+docker rmi "$(docker images -q -f dangling=true)"
 
 IFS="$OLD_IFS"


### PR DESCRIPTION
Michał noticed customers code may reside in a docker container and may not be cleaned with srm of local directory. This PR extends the procedure to clean such containers and volumes somehow.