### PR TITLE
strict flags for keychain config script

### DIFF
--- a/configure-keychain.sh
+++ b/configure-keychain.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -exuo pipefail
+
 sudo apt-get remove gnome-keyring
 sudo apt-get install keychain
 


### PR DESCRIPTION
make the script fail fast in case of any error (eg. parallel `apt-get` is already running)