### PR TITLE
Add ignoreRevsFile in .gitconfig

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -56,5 +56,7 @@
     aliases = !git config --get-regexp 'alias.*' | colrm 1 6 | sed 's/[ ]/ = /'
 [push]
 	default = upstream
+[blame]
+    ignoreRevsFile = .git-blame-ignore-revs
 #[commit]
 #   gpgsign = true


### PR DESCRIPTION
Since we are starting to format codebases with ruff, this is gonna come in handy for local blame viewing.