### PR TITLE
Revert "Add ignoreRevsFile in .gitconfig"

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -56,7 +56,5 @@
     aliases = !git config --get-regexp 'alias.*' | colrm 1 6 | sed 's/[ ]/ = /'
 [push]
 	default = upstream
-[blame]
-    ignoreRevsFile = .git-blame-ignore-revs
 #[commit]
 #   gpgsign = true


### PR DESCRIPTION
Reverts reef-technologies/handbook#118

Apparently, a missing `.git-blame-ignore-revs` file will cause `git blame` to error. There doesn't seem to be a way to globally set this option but skip if missing.