### PR TITLE
Add shell option with `set` recommendation in code conventions

### DIFF
--- a/bin/fix-shared-clipboard
+++ b/bin/fix-shared-clipboard
@@ -1,4 +1,6 @@
-#!/bin/bash -ux
+#!/bin/bash
+set -ux
+
 killall VBoxClient
 sleep 1
 /usr/bin/VBoxClient --clipboard

--- a/docs/Code_conventions.md
+++ b/docs/Code_conventions.md
@@ -77,6 +77,9 @@ We skip it after `**kwargs` as no argument will ever follow it.
 
 <https://sipb.mit.edu/doc/safe-shell/>
 
+Shell options should be set with explicit `set` (or, `shopt`) built-in command, not in the shebang, to ensure they are always set.
+When options are set in the shebang of a script, they are ignored when the script is directly invoked (like `bash script.sh`).
+
 ### SemBr
 
 Use [Semantic Line Breaks](https://sembr.org/) whenever line breaks do not influence rendered document.


### PR DESCRIPTION
Add the discussion from slack #python about setting shell options in the code conventions.