### PR TITLE
remove env variables related to virtualenv 

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -131,8 +131,8 @@ if [ -x /usr/bin/mint-fortune ]; then
 fi
 
 # Virtualenv
-export VIRTUALENV_PYTHON=/usr/bin/python3
-export VIRTUALENVWRAPPER_PYTHON="$VIRTUALENV_PYTHON"
+# export VIRTUALENV_PYTHON=/usr/bin/python3
+# export VIRTUALENVWRAPPER_PYTHON="$VIRTUALENV_PYTHON"
 
 export WORKON_HOME=$HOME/.virtualenvs
 export PROJECT_HOME=$HOME/projects


### PR DESCRIPTION
Variables `VIRTUALENV_PYTHON=/usr/bin/python3`, `VIRTUALENVWRAPPER_PYTHON=$VIRTUALENV_PYTHON`

are probably seldom used, and they can cause long debugging when using virtualenv, as they override any other specifier  of python version when using virtualenv. 

<!--
Please run `nox -s format` locally before committing changes.
You can remove this comment before creating PR.
-->
