### PR TITLE
Normalize rich-text runs into serializable form

### DIFF
--- a/notion_sync/README.md
+++ b/notion_sync/README.md
@@ -39,6 +39,9 @@ CI runs the nox session:
 - `src/mapper.ts` — the complete "what translates to what" catalog: 
   - every block type and rich-text run, one handler each
   - every lossy equivalence (toggle → bold summary line, underline → italic, …) is a policy comment at its decision site
+  - rich-text runs are normalized before translation — empty runs dropped, identically-styled neighbors merged (Notion splits spans on comment anchors and color changes), edge whitespace hoisted out of styled runs (CommonMark forbids a closing delimiter next to whitespace)
+  - trailing whitespace and hard breaks at a block's edge are dropped after translation, including inside a trailing link's label (insignificant, and would otherwise serialize as `&#x20;` noise or a dangling `\`)
+  - styled spans that still end up adjacent are separated by an empty HTML comment, which renders as nothing but keeps their delimiters from fusing (`**a****b**` would re-parse as literal asterisks)
   - translation decisions live only here
 - `src/main.ts` — everything else
 

--- a/notion_sync/package-lock.json
+++ b/notion_sync/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "notion_sync",
+  "name": "notion-sync",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "notion-sync",
       "dependencies": {
         "@notionhq/client": "^5.22.0",
         "@types/mdast": "^4.0.4",

--- a/notion_sync/src/mapper.ts
+++ b/notion_sync/src/mapper.ts
@@ -276,10 +276,107 @@ function linkParagraph(url: string, caption: string, ctx: MapperContext): FlowCo
 
 // ---------- Rich text -> mdast phrasing ----------
 
+// Notion styles text as flat runs with style flags and freely splits one
+// styled span into several runs (comment anchors, color changes do this).
+// The run list is repaired before translation — shapes markdown cannot spell
+// are rewritten into render-equivalent ones, stage by stage below.
 export function richTextToMdast(runs: RichTextItemResponse[], ctx: MapperContext): PhrasingContent[] {
-  const nodes = runs.flatMap((run) => runToMdast(run, ctx));
-  trimTrailingSpace(nodes);
-  return nodes;
+  return runs
+    .filter((run) => !(run.type === 'text' && run.text.content === ''))
+    .reduce(mergeIdenticallyStyled, [])
+    .flatMap(hoistEdgeWhitespace)
+    .flatMap((run) => runToMdast(run, ctx))
+    .reduceRight(trimTrailing, [])
+    .flatMap(separateAdjacentSpans);
+}
+
+type TextRun = Extract<RichTextItemResponse, { type: 'text' }>;
+
+// Trailing whitespace at the end of a block is insignificant; serialized it
+// would become "&#x20;" noise or a dangling hard break. reduceRight reducer:
+// an empty accumulator means the block edge is still being trimmed; once a
+// visible node lands, everything before it passes through untouched. Works on
+// nodes rather than runs so it reaches inside a trailing link (mention labels
+// included).
+function trimTrailing(trailing: PhrasingContent[], node: PhrasingContent): PhrasingContent[] {
+  if (trailing.length > 0) return [node, ...trailing];
+  if (node.type === 'break') return trailing;
+  if ('children' in node) {
+    const children = node.children.reduceRight(trimTrailing, []);
+    return children.length === 0 ? trailing : [{ ...node, children }];
+  }
+  if (node.type === 'text') {
+    const value = node.value.trimEnd();
+    return value === '' ? trailing : [{ ...node, value }];
+  }
+  return [node]; // inlineCode/inlineMath content is verbatim; never trim it
+}
+
+// Merged back into one run, a split span serializes as a single markdown span.
+function mergeIdenticallyStyled(merged: RichTextItemResponse[], run: RichTextItemResponse): RichTextItemResponse[] {
+  const prev = merged[merged.length - 1];
+  if (prev?.type === 'text' && run.type === 'text' && sameStyling(prev, run)) {
+    merged[merged.length - 1] = { ...prev, text: { ...prev.text, content: prev.text.content + run.text.content } };
+  } else {
+    merged.push(run);
+  }
+  return merged;
+}
+
+// POLICY: color is ignored — it has no markdown equivalent, so runs differing
+// only in color are the same span to us.
+function sameStyling(a: TextRun, b: TextRun): boolean {
+  const x = a.annotations;
+  const y = b.annotations;
+  return (
+    x.bold === y.bold &&
+    x.italic === y.italic &&
+    x.strikethrough === y.strikethrough &&
+    x.underline === y.underline &&
+    x.code === y.code &&
+    (a.text.link?.url ?? null) === (b.text.link?.url ?? null)
+  );
+}
+
+// CommonMark forbids a closing delimiter next to whitespace, so edge
+// whitespace moves out of styled runs into plain ones. Inline code keeps its
+// whitespace (it is content there, and backtick delimiters tolerate it);
+// linked runs need no hoisting either, the brackets already separate the
+// styling delimiters from the whitespace.
+function hoistEdgeWhitespace(run: RichTextItemResponse): RichTextItemResponse[] {
+  if (run.type !== 'text' || run.text.link) return [run];
+  const a = run.annotations;
+  if (a.code || !(a.bold || a.italic || a.strikethrough || a.underline)) return [run];
+  const content = run.text.content;
+  const lead = content.match(/^\s+/)?.[0] ?? '';
+  if (lead === content) return [plainRun(run, content)]; // whitespace-only styled run
+  const trail = content.match(/\s+$/)?.[0] ?? '';
+  const out: RichTextItemResponse[] = [];
+  if (lead) out.push(plainRun(run, lead));
+  out.push({ ...run, text: { ...run.text, content: content.slice(lead.length, content.length - trail.length) } });
+  if (trail) out.push(plainRun(run, trail));
+  return out;
+}
+
+function plainRun(base: TextRun, content: string): RichTextItemResponse {
+  return {
+    ...base,
+    annotations: { ...base.annotations, bold: false, italic: false, strikethrough: false, underline: false, code: false },
+    text: { content, link: null },
+    plain_text: content,
+  };
+}
+
+const DELIMITED = new Set(['strong', 'emphasis', 'delete', 'inlineCode', 'inlineMath']);
+
+// Two styled spans serialized back to back make their delimiters touch and
+// fuse (`**a****b**` re-parses as one span with literal asterisks). An empty
+// HTML comment between them renders as nothing and keeps the delimiters
+// apart. Links need none: their brackets already separate.
+function separateAdjacentSpans(node: PhrasingContent, i: number, nodes: PhrasingContent[]): PhrasingContent[] {
+  return i > 0 && DELIMITED.has(node.type) && DELIMITED.has(nodes[i - 1]!.type)
+    ? [{ type: 'html', value: '<!-- -->' }, node]
+    : [node];
 }
 
 function runToMdast(run: RichTextItemResponse, ctx: MapperContext): PhrasingContent[] {
@@ -339,30 +436,6 @@ function breaksToSpaces(nodes: PhrasingContent[]): PhrasingContent[] {
     if ('children' in node) return { ...node, children: breaksToSpaces(node.children) };
     return node;
   });
-}
-
-// Notion rich text may carry insignificant trailing spaces (and, at the end of
-// a block, trailing breaks); serialized they would become "&#x20;" noise or a
-// dangling hard break, so trim them off.
-function trimTrailingSpace(nodes: PhrasingContent[]): void {
-  const last = nodes[nodes.length - 1];
-  if (!last) return;
-  if (last.type === 'break') {
-    nodes.pop();
-    trimTrailingSpace(nodes);
-    return;
-  }
-  if ('children' in last) {
-    trimTrailingSpace(last.children);
-    if (last.children.length > 0) return;
-  } else if (last.type === 'text') {
-    last.value = last.value.trimEnd();
-    if (last.value !== '') return;
-  } else {
-    return; // inlineCode/inlineMath content is verbatim; never trim it
-  }
-  nodes.pop();
-  trimTrailingSpace(nodes);
 }
 
 const plainText = (runs: RichTextItemResponse[]): string => runs.map((run) => run.plain_text).join('');


### PR DESCRIPTION
https://github.com/reef-technologies/handbook/pull/160#discussion_r3643486331

Notion styles text as a list of strings (==runs), each containing a set of "styles" applied. Some combinations of these are unrepresentable in Markdown, e.g. ~`[strong("Foo"), strong("bar")]` renders as `**Foo****bar**` making the asterisks ambiguous to Markdown parsers. Notion doesn't have this limitation.

Additionally, CommonMark forbids dangling whitespace before the closing part of some runs (e.g. `**Foo **` is illegal) which further trips up some parsers.

This PR:
- hoists the whitespace out of runs where it would produce illegal Markdown
- merges subsequent runs with identical styling, specifically fixing an issue where a comment in Notion splits a run into two identically styled runs
- for runs that cannot be merged like that - inserts a `<!-- -->` separator.