### PR TITLE
Rendering links to out-of-handbook-tree Notion pages

### DIFF
--- a/notion_sync/README.md
+++ b/notion_sync/README.md
@@ -42,6 +42,7 @@ CI runs the nox session:
   - rich-text runs are normalized before translation — empty runs dropped, identically-styled neighbors merged (Notion splits spans on comment anchors and color changes), edge whitespace hoisted out of styled runs (CommonMark forbids a closing delimiter next to whitespace)
   - trailing whitespace and hard breaks at a block's edge are dropped after translation, including inside a trailing link's label (insignificant, and would otherwise serialize as `&#x20;` noise or a dangling `\`)
   - styled spans that still end up adjacent are separated by an empty HTML comment, which renders as nothing but keeps their delimiters from fusing (`**a****b**` would re-parse as literal asterisks)
+  - a mention of an out-of-tree page renders as its Notion URL — the API withholds titles of pages not shared with the integration — and emits a warning, which in CI also surfaces as a GitHub annotation
   - translation decisions live only here
 - `src/main.ts` — everything else
 

--- a/notion_sync/src/main.ts
+++ b/notion_sync/src/main.ts
@@ -197,7 +197,10 @@ function renderPage(placedPage: PlacedPage, placed: Map<string, PlacedPage>, dow
       return target ? { path: relativeTo(file, target.file), title: target.page.title } : null;
     },
     saveAttachment: scheduleDownload,
-    warn: (message) => console.error(`warning: ${page.title}: ${message}`),
+    warn: (message) => {
+      console.error(`warning: ${page.title}: ${message}`);
+      if (process.env['GITHUB_ACTIONS']) console.log(`::warning title=notion_sync::${file}: ${message}`);
+    },
   };
 
   const tree: Root = { type: 'root', children: blocksToMdast(page.blocks, ctx) };

--- a/notion_sync/src/mapper.ts
+++ b/notion_sync/src/mapper.ts
@@ -400,8 +400,21 @@ function runToMdast(run: RichTextItemResponse, ctx: MapperContext): PhrasingCont
       // All other mention kinds (user, date, ...) have no markdown equivalent
       // and fall back to their plain text.
       if (run.mention.type === 'page') {
-        nodes = [{ type: 'text', value: ctx.resolvePage(run.mention.page.id)?.title ?? run.plain_text }];
-        url = run.href;
+        const target = ctx.resolvePage(run.mention.page.id);
+        if (target) {
+          nodes = [{ type: 'text', value: target.title }];
+          url = run.href;
+        } else {
+          // POLICY: for an out-of-tree page the API withholds the title
+          // (plain_text reads "Untitled" unless the page is shared with the
+          // integration), so the URL doubles as the label and a warning is
+          // emitted. Nothing to do here - we can't and shouldn't pull a page
+          // from the outside of the explicitly public handbook tree.
+          const mentionUrl = `https://www.notion.so/${run.mention.page.id.replace(/-/g, '')}`;
+          ctx.warn(`out-of-tree page mention ${run.mention.page.id}: title unavailable, rendering the URL`);
+          nodes = [{ type: 'text', value: mentionUrl }];
+          url = mentionUrl;
+        }
       } else {
         nodes = [{ type: 'text', value: run.plain_text }];
       }


### PR DESCRIPTION
https://github.com/reef-technologies/handbook/pull/160#discussion_r3643463304

Currently the link (or rather, the **page mention**) is rendered verbatim as Notion reports it, using the url and title we get.

But for pages that the sync integration has no access to, Notion just returns "Untitled" as the page title, but otherwise the mention is structurally the same.

This PR makes it so that if the page linked to does not exist in the handbook tree, it will always just use the page URL as its title, no matter what Notion responds with.

It also add a CI warning about a link that is now in a public handbook but effectively unreachable publicly.

---

Branched off of #161, so review and merge #161 first.